### PR TITLE
Use CI structure from pear

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,51 +1,110 @@
----
 version: 2
+
+global_defaults: &global_defaults
+  working_directory: ~/jay
+
+build_defaults: &build_defaults
+  steps:
+    - checkout
+    - run:
+        name: Create yarn cache key
+        command: cp yarn.lock yarn-lock-cache.key && node --version >> yarn-lock-cache.key
+    - restore_cache:
+        name: Restore yarn cache
+        key: yarn-{{ checksum "yarn-lock-cache.key" }}
+    - run:
+        name: Yarn install
+        command: yarn install
+    - save_cache:
+        name: Save yarn cache
+        key: yarn-{{ checksum "yarn-lock-cache.key" }}
+        paths:
+          - node_modules/
+
+test_defaults: &test_defaults
+  steps:
+    - checkout
+    - run:
+        name: Create yarn cache key
+        command: cp yarn.lock yarn-lock-cache.key && node --version >> yarn-lock-cache.key
+    - restore_cache:
+        name: Restore yarn cache
+        key: yarn-{{ checksum "yarn-lock-cache.key" }}
+    - run:
+        name: Yarn install
+        command: yarn install
+    - run:
+        name: Get version
+        command: ./bin/run --version
+    - run:
+        name: Show help
+        command: ./bin/run --help
+    # - run:
+    #     name: Prettier check
+    #     command: yarn prettier-check
+    # - run:
+    #     name: Lint
+    #     command: yarn lint
+    # - run:
+    #     name: Type check
+    #     command: yarn type-check
+    - run:
+        name: Run tests
+        command: yarn test
+
+node_10_defaults: &node_10_defaults
+  <<: *global_defaults
+  docker:
+    - image: node:10.20.1
+
+node_12_defaults: &node_12_defaults
+  <<: *global_defaults
+  docker:
+    - image: node:12.16.2
+
+node_14_defaults: &node_14_defaults
+  <<: *global_defaults
+  docker:
+    - image: node:14.0.0
+
 jobs:
-  node-latest: &test
-    docker:
-      - image: node:latest
-    working_directory: ~/cli
-    steps:
-      - checkout
-      - restore_cache: &restore_cache
-          keys:
-            - v1-npm-{{checksum ".circleci/config.yml"}}-{{checksum "yarn.lock"}}
-            - v1-npm-{{checksum ".circleci/config.yml"}}
-      - run:
-          name: Install dependencies
-          command: yarn
-      - run: ./bin/run --version
-      - run: ./bin/run --help
-      - run:
-          name: Testing
-          command: yarn test
-  node-8:
-    <<: *test
-    docker:
-      - image: node:8
-  cache:
-    <<: *test
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: yarn
-      - save_cache:
-          key: v1-npm-{{checksum ".circleci/config.yml"}}-{{checksum "yarn.lock"}}
-          paths:
-            - ~/cli/node_modules
-            - /usr/local/share/.cache/yarn
-            - /usr/local/share/.config/yarn
+  build-node-10:
+    <<: *node_10_defaults
+    <<: *build_defaults
+
+  test-node-10:
+    <<: *node_10_defaults
+    <<: *test_defaults
+
+  build-node-12:
+    <<: *node_12_defaults
+    <<: *build_defaults
+
+  test-node-12:
+    <<: *node_12_defaults
+    <<: *test_defaults
+
+  build-node-14:
+    <<: *node_14_defaults
+    <<: *build_defaults
+
+  test-node-14:
+    <<: *node_14_defaults
+    <<: *test_defaults
 
 workflows:
   version: 2
-  "jay":
+  default:
     jobs:
-      - node-latest
-      - node-8
-      - cache:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+      - build-node-10
+      - build-node-12
+      - build-node-14
+      - test-node-10:
+          requires:
+            - build-node-10
+      - test-node-12:
+          requires:
+            - build-node-12
+      - test-node-14:
+          requires:
+            - build-node-14


### PR DESCRIPTION
I was having issues building this project, but it turned out to be fixed by stopping the CircleCI building which removes the SSH keys and then starting it again which regenerates them for you.

But while I was at it I figured it would be good to copy the CI structure from pear so I've done that although I don't have the deploy step. I'll add that at some point.