### PR TITLE
Update after init and raw commands

### DIFF
--- a/src/commands/keys/init.ts
+++ b/src/commands/keys/init.ts
@@ -1,11 +1,12 @@
 import { Command } from "@oclif/command"
 import { Jay } from "../../shared/Jay"
-import { initKeys } from "../../helpers/keys"
+import { initKeys, updateKeys } from "../../helpers/keys"
 
 export default class Init extends Command {
   static description = "make directory structure and symlink"
 
   async run(): Promise<void> {
     initKeys(Jay.config)
+    updateKeys(Jay.config)
   }
 }

--- a/src/commands/keys/raw.ts
+++ b/src/commands/keys/raw.ts
@@ -1,6 +1,6 @@
 import { Command } from "@oclif/command"
 import { Jay } from "../../shared/Jay"
-import { addRawKey } from "../../helpers/keys"
+import { addRawKey, updateKeys } from "../../helpers/keys"
 
 export default class Raw extends Command {
   static description = "add a raw key to the unmanaged list (then update)"
@@ -10,5 +10,6 @@ export default class Raw extends Command {
   async run(): Promise<void> {
     const rawPath: string = this.parse(Raw).argv[0]
     addRawKey(Jay.config, rawPath)
+    updateKeys(Jay.config)
   }
 }

--- a/test/commands/keys/init.test.ts
+++ b/test/commands/keys/init.test.ts
@@ -1,0 +1,12 @@
+import Init from "../../../src/commands/keys/init"
+import { mockKeysHelper } from "../../helpers"
+
+describe("Init", () => {
+  it("inits and then updates", async () => {
+    const mockInitKeys = mockKeysHelper("initKeys")
+    const mockUpdateKeys = mockKeysHelper("updateKeys")
+    await Init.run([])
+    expect(mockInitKeys).toHaveBeenCalled()
+    expect(mockUpdateKeys).toHaveBeenCalled()
+  })
+})

--- a/test/commands/keys/raw.test.ts
+++ b/test/commands/keys/raw.test.ts
@@ -1,0 +1,12 @@
+import Raw from "../../../src/commands/keys/raw"
+import { mockKeysHelper } from "../../helpers"
+
+describe("Raw", () => {
+  it("adds raw key and then updates", async () => {
+    const mockAddRawKey = mockKeysHelper("addRawKey")
+    const mockUpdateKeys = mockKeysHelper("updateKeys")
+    await Raw.run([])
+    expect(mockAddRawKey).toHaveBeenCalled()
+    expect(mockUpdateKeys).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This PR updates a couple more commands to ensure they are updating the underlying keys file as things change. We're still in need of some more unit-level testing, but we're getting there!