### PR TITLE
Add feature commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
       "keys": {
         "description": "Manage authorized keys."
       },
+      "feature": {
+        "description": "Setup feature branches and PRs."
+      },
       "sharpen": {
         "description": "Sharpen your tools."
       }

--- a/src/commands/feature/open_pr.ts
+++ b/src/commands/feature/open_pr.ts
@@ -1,0 +1,39 @@
+import { Command } from "@oclif/command"
+import { Jay } from "../../shared/Jay"
+
+const computePrBody = (
+  jiraLinks: string[],
+  githubTeamNames: string[]
+): string => {
+  const placeholder =
+    "This is a placeholder - please update with an awesome PR description!"
+  const tickets = jiraLinks.join("\n")
+  const mentions =
+    githubTeamNames.length > 0 && `/cc ${githubTeamNames.join(" ")}`
+  const body = [placeholder, tickets, mentions].filter(Boolean).join("\n\n")
+  return body
+}
+
+export default class OpenPr extends Command {
+  static description = "Open PR on upstream from feature branch."
+
+  async run(): Promise<void> {
+    const currentBranchCommand = "git branch --show-current"
+    const branchName = Jay.utils.exec(currentBranchCommand)
+
+    const getDescriptionCommand = `git config --get branch.${branchName}.description`
+    const branchDescription = Jay.utils.exec(getDescriptionCommand)
+    const branchInfo = JSON.parse(branchDescription)
+    const { githubTeamNames, jiraLinks, prTitle } = branchInfo
+
+    const renameBranchCommand = `git branch -m jonallured/${branchName}`
+    Jay.utils.exec(renameBranchCommand)
+
+    const pushCommand = `git push --set-upstream upstream HEAD`
+    Jay.utils.exec(pushCommand)
+
+    const prBody = computePrBody(jiraLinks, githubTeamNames)
+    const prCommand = `gh pr create --title '${prTitle}' --body '${prBody}' --web`
+    Jay.utils.exec(prCommand)
+  }
+}

--- a/src/commands/feature/start.ts
+++ b/src/commands/feature/start.ts
@@ -1,0 +1,111 @@
+import { Command, flags } from "@oclif/command"
+import { Jay } from "../../shared/Jay"
+
+const computeGithubTeamNames = (githubTeams: string[]): string[] => {
+  const githubTeamNames = githubTeams.map((name) => `@${name}`)
+  return githubTeamNames
+}
+
+const artsyTeams = [
+  "artsy/collector-experience",
+  "artsy/fx-devs",
+  "artsy/grow-devs",
+  "artsy/purchase-devs",
+  "artsy/px-devs",
+]
+
+const computeJiraLinks = (jiraTickets: string[]): string[] => {
+  const links = jiraTickets.map(
+    (ticket) => `https://artsyproduct.atlassian.net/browse/${ticket}`
+  )
+  return links
+}
+
+const computeBranchName = (
+  featureName: string,
+  featureType: string
+): string => {
+  const parts = [featureType, ...featureName.split(" ")]
+  const branchName = parts.join("-").toLowerCase()
+  return branchName
+}
+
+const computePRTitle = (featureName: string, featureType: string): string => {
+  const prTitle = [featureType, featureName].join(": ")
+  return prTitle
+}
+
+const featureTypes = [
+  "chore",
+  "docs",
+  "feat",
+  "fix",
+  "refactor",
+  "style",
+  "test",
+]
+
+export default class Start extends Command {
+  static description = "Start a feature branch."
+
+  static args = [
+    {
+      name: "featureName",
+      required: true,
+      description: "Name of the feature being worked.",
+    },
+    {
+      name: "featureType",
+      required: true,
+      description: "Type of the feature being worked.",
+      default: "feat",
+      options: featureTypes,
+    },
+  ]
+
+  static flags = {
+    jira: flags.string({
+      char: "j",
+      default: [],
+      description: "Jira ticket number like this: GRO-4.",
+      multiple: true,
+      required: false,
+    }),
+    team: flags.string({
+      char: "t",
+      default: [],
+      description: "GitHub team to CC on PR.",
+      multiple: true,
+      options: artsyTeams,
+      required: false,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { args, flags } = this.parse(Start)
+
+    const { featureName, featureType } = args
+    const { jira: jiraTickets, team: githubTeams } = flags
+
+    const branchName = computeBranchName(featureName, featureType)
+    const prTitle = computePRTitle(featureName, featureType)
+
+    const jiraLinks = computeJiraLinks(jiraTickets)
+    const githubTeamNames = computeGithubTeamNames(githubTeams)
+
+    const newBranchCommand = `git checkout -b ${branchName}`
+    Jay.utils.exec(newBranchCommand)
+
+    const pushCommand = `git push --set-upstream origin ${branchName}`
+    Jay.utils.exec(pushCommand)
+
+    const branchInfo = {
+      githubTeamNames,
+      jiraLinks,
+      prTitle,
+    }
+    const branchDescription = JSON.stringify(branchInfo)
+    const setDescriptionCommand = `git config branch.${branchName}.description '${branchDescription}'`
+    Jay.utils.exec(setDescriptionCommand)
+  }
+}


### PR DESCRIPTION
This PR adds some helpful commands to assist in complying with some new workflows at Artsy around opening PRs. It's meant to be used like so:

```
$ jay feature:start "Best new feature" --jira GRO-1 --jira GRO-5 --team artsy/grow-devs
// do your work here
$ jay feature:open_pr
```

That should open a PR against upstream with the branch named correctly, the PR setup with a good title and body that includes Jira links and team mentions.