### PR TITLE
Append Jira ticket to pr title

### DIFF
--- a/src/commands/feature/start.ts
+++ b/src/commands/feature/start.ts
@@ -73,7 +73,7 @@ export default class Start extends Command {
     const { jira: jiraTickets, team: githubTeams } = flags
 
     const branchName = computeBranchName(featureName, featureType)
-    const prTitle = computePrTitle(featureName, featureType)
+    const prTitle = computePrTitle(featureName, featureType, jiraTickets)
 
     const jiraLinks = computeJiraLinks(jiraTickets)
     const githubTeamNames = computeGithubTeamNames(githubTeams)

--- a/src/helpers/feature.ts
+++ b/src/helpers/feature.ts
@@ -38,8 +38,14 @@ export const computePrBody = (
 
 export const computePrTitle = (
   featureName: string,
-  featureType: string
+  featureType: string,
+  jiraTickets: string[]
 ): string => {
-  const prTitle = [featureType, featureName].join(": ")
-  return prTitle
+  const prefix = `${featureType}:`
+  const suffix = jiraTickets[0]
+
+  const parts = [prefix, featureName, suffix].filter(Boolean)
+  const title = parts.join(" ")
+
+  return title
 }

--- a/test/helpers/feature.test.ts
+++ b/test/helpers/feature.test.ts
@@ -128,7 +128,15 @@ describe("computePrTitle", () => {
   it("prepends the type to the feature name", () => {
     const featureName = "Update list of Repos"
     const featureType = "chore"
-    const prTitle = computePrTitle(featureName, featureType)
+    const prTitle = computePrTitle(featureName, featureType, [])
     expect(prTitle).toEqual("chore: Update list of Repos")
+  })
+
+  it("appends the Jira info to the feature name", () => {
+    const featureName = "Update list of Repos"
+    const featureType = "chore"
+    const jiraTickets = ["GRO-7"]
+    const prTitle = computePrTitle(featureName, featureType, jiraTickets)
+    expect(prTitle).toEqual("chore: Update list of Repos GRO-7")
   })
 })


### PR DESCRIPTION
Looks like the cool thing to do is add the Jira ticket info the end of the PR title. This ensures that the PR can be linked up with the Jira ticket. I think this is the best integration because it gets one right to the PR with all the context and discussion.