### PR TITLE
Catch command errors so they can't throw

### DIFF
--- a/src/commands/feature/nuke.ts
+++ b/src/commands/feature/nuke.ts
@@ -15,14 +15,14 @@ export default class Nuke extends Command {
   async run(): Promise<void> {
     const { branchName } = this.parse(Nuke).args
 
-    const localCommand = `git branch -D ${branchName}`
+    const localCommand = `git branch -D ${branchName} || echo nope`
     Jay.utils.exec(localCommand)
 
-    const upstreamCommand = `git push upstream :${branchName}`
+    const upstreamCommand = `git push upstream --delete ${branchName} || echo nope`
     Jay.utils.exec(upstreamCommand)
 
     const originBranchName = branchName.split("/").pop()
-    const originCommand = `git push origin :${originBranchName}`
+    const originCommand = `git push origin --delete ${originBranchName} || echo nope`
     Jay.utils.exec(originCommand)
   }
 }


### PR DESCRIPTION
The series of commands that nuke a branch will sometimes error - this is actually expected behavior. So this PR just adds a bashism to catch those errors and return a zero code so that subsequent commands still run.

There might be a cooler way of doing this but I couldn't think of it...