### PR TITLE
Simplify releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ I've set things up so that CircleCI can release new package versions
 automatically based on pushing tags, so one can cut a new version like so:
 
 ```
-$ ./bin/release 0.0.1 0.0.2
+$ ./bin/release
 ```
 
 That will:

--- a/bin/release
+++ b/bin/release
@@ -1,16 +1,13 @@
 #! /bin/sh
 set -ex
 
-old_version=$1
-new_version=$2
+new_version=$(npm version minor --git-tag-version=false)
 
-version_files="package.json"
-commit_message="Bumping version numbers for $new_version"
-tag_message="Tagging version $new_version"
-
-sed -i "" "s/$old_version/$new_version/g" $version_files
-git add .
-git commit --message "$commit_message"
+git add package.json
+git commit --message "Bumping version number for $new_version"
 git push --force origin main
-git tag --annotate v$new_version --message "$tag_message"
+
+git tag --annotate $new_version --message "Tagging $new_version"
 git push origin --tags
+
+gh release create $new_version --generate-notes


### PR DESCRIPTION
Over on Pear I landed on a more simple way of releasing that just increments the minor version of the package every time so I'm going to use that here too.