### PR TITLE
Add support for build me features

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.10.0"
+        uses: "pascalgn/automerge-action@v0.16.2"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_DELETE_BRANCH: true

--- a/src/commands/feature/start.ts
+++ b/src/commands/feature/start.ts
@@ -33,6 +33,12 @@ export default class Start extends Command {
   }
 
   static flags = {
+    buildMe: Flags.boolean({
+      char: "b",
+      default: false,
+      description: "Whether to append build-me to branch name.",
+      required: false,
+    }),
     jira: Flags.string({
       char: "j",
       default: [],
@@ -46,9 +52,9 @@ export default class Start extends Command {
     const { args, flags } = await this.parse(Start)
 
     const { featureName, featureType } = args
-    const { jira: jiraTickets } = flags
+    const { buildMe, jira: jiraTickets } = flags
 
-    const branchName = computeBranchName(featureName, featureType)
+    const branchName = computeBranchName(featureName, featureType, buildMe)
     const prTitle = computePrTitle(featureName, featureType, jiraTickets)
 
     const jiraLinks = computeJiraLinks(jiraTickets)

--- a/src/helpers/feature.ts
+++ b/src/helpers/feature.ts
@@ -1,9 +1,13 @@
 export const computeBranchName = (
   featureName: string,
   featureType: string,
+  buildMe: boolean,
 ): string => {
-  const cleanedName = featureName.replace(/[^a-zA-Z ]/g, "")
+  const cleanedName = featureName.replace(/[^a-zA-Z0-9 ]/g, "")
   const parts = [featureType, ...cleanedName.split(" ")]
+  if (buildMe) {
+    parts.push("build-me")
+  }
   const branchName = parts.join("-").toLowerCase()
   return branchName
 }

--- a/test/helpers/feature.test.ts
+++ b/test/helpers/feature.test.ts
@@ -8,11 +8,12 @@ import {
 } from "../../src/helpers/feature"
 
 describe("computeBranchName", () => {
-  it("appends the type to the feature name", () => {
+  it("prepends the type to the feature name", () => {
     const featureName = "Updates"
     const featureType = "chore"
+    const buildMe = false
 
-    const branchName = computeBranchName(featureName, featureType)
+    const branchName = computeBranchName(featureName, featureType, buildMe)
 
     expect(branchName).toEqual("chore-updates")
   })
@@ -20,19 +21,41 @@ describe("computeBranchName", () => {
   it("removes case from feature name and replaces spaces with dashes", () => {
     const featureName = "Update list of Repos"
     const featureType = "chore"
+    const buildMe = false
 
-    const branchName = computeBranchName(featureName, featureType)
+    const branchName = computeBranchName(featureName, featureType, buildMe)
 
     expect(branchName).toEqual("chore-update-list-of-repos")
   })
 
-  it("removes special characters and numbers", () => {
-    const featureName = "This feature rules!1!"
+  it("removes special characters", () => {
+    const featureName = "This feature rules!"
     const featureType = "feat"
+    const buildMe = false
 
-    const branchName = computeBranchName(featureName, featureType)
+    const branchName = computeBranchName(featureName, featureType, buildMe)
 
     expect(branchName).toEqual("feat-this-feature-rules")
+  })
+
+  it("treats numbers as letters", () => {
+    const featureName = "Step 1: Make the change easy"
+    const featureType = "feat"
+    const buildMe = false
+
+    const branchName = computeBranchName(featureName, featureType, buildMe)
+
+    expect(branchName).toEqual("feat-step-1-make-the-change-easy")
+  })
+
+  it("appends build-me", () => {
+    const featureName = "Updates"
+    const featureType = "chore"
+    const buildMe = true
+
+    const branchName = computeBranchName(featureName, featureType, buildMe)
+
+    expect(branchName).toEqual("chore-updates-build-me")
   })
 })
 


### PR DESCRIPTION
This PR adds support for a flag that can indicate that the branch name should contain `build-me`. Used like this:

```bash
$ jay feature:start "Step 1: Make the change easy" chore --build-me
```

Which should result in a branch name like this: `step-1-make-the-change-easy-build-me` and I want that because on certain Artsy projects this opts the PR into a complete CI build.