### PR TITLE
Skip PR body for some projects

### DIFF
--- a/src/commands/feature/open_pr.ts
+++ b/src/commands/feature/open_pr.ts
@@ -20,8 +20,14 @@ export default class OpenPr extends Command {
     const pushCommand = `git push --set-upstream upstream HEAD`
     Jay.utils.exec(pushCommand)
 
-    const prBody = computePrBody(jiraLinks)
-    const prCommand = `gh pr create --title '${prTitle}' --body '${prBody}' --web`
+    let prCommand = `gh pr create --title '${prTitle}' --web`
+
+    const projectName = `basename "$PWD"`
+    const prBody = computePrBody(projectName, jiraLinks)
+    if (prBody) {
+      prCommand = `${prCommand} --body '${prBody}'`
+    }
+
     Jay.utils.exec(prCommand)
   }
 }

--- a/src/helpers/feature.ts
+++ b/src/helpers/feature.ts
@@ -24,7 +24,15 @@ export const placeholderPrBody =
 
 export const teamMention = "/cc @artsy/amber-devs"
 
-export const computePrBody = (jiraLinks: string[]): string => {
+const projectsToSkip = ["eigen", "energy"]
+
+export const computePrBody = (
+  projectName: string,
+  jiraLinks: string[],
+): string | undefined => {
+  const skipBody = projectsToSkip.includes(projectName)
+  if (skipBody) return
+
   const tickets = jiraLinks.join("\n")
   const body = [placeholderPrBody, tickets, teamMention]
     .filter(Boolean)

--- a/test/helpers/feature.test.ts
+++ b/test/helpers/feature.test.ts
@@ -89,22 +89,33 @@ describe("computeJiraLinks", () => {
 })
 
 describe("computePrBody", () => {
-  describe("with no jira links", () => {
+  describe("with a project that should have a body and no jira links", () => {
     it("returns the placeholder pr body with team mention", () => {
+      const projectName = "gravity"
       const jiraLinks: string[] = []
-      const body = computePrBody(jiraLinks)
+      const body = computePrBody(projectName, jiraLinks)
       expect(body).toContain(placeholderPrBody)
       expect(body).toContain(teamMention)
     })
   })
 
+  describe("with a project that should skip the body", () => {
+    it("returns undefined", () => {
+      const projectName = "eigen"
+      const jiraLinks: string[] = []
+      const body = computePrBody(projectName, jiraLinks)
+      expect(body).toBeUndefined()
+    })
+  })
+
   describe("with some jira links", () => {
     it("adds those links to the body", () => {
+      const projectName = "gravity"
       const jiraLinks = [
         "https://artsyproduct.atlassian.net/browse/GRO-4",
         "https://artsyproduct.atlassian.net/browse/CX-7",
       ]
-      const body = computePrBody(jiraLinks)
+      const body = computePrBody(projectName, jiraLinks)
       expect(body).toContain(jiraLinks[0])
       expect(body).toContain(jiraLinks[1])
     })


### PR DESCRIPTION
Some projects have PR templates and for those I want to skip populating the body in favor of that template. The approach here is to grab the current folder's basename and use that as a "project name" which I can then check against a list and bail when appropriate.